### PR TITLE
feat: Export more functions from the library

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -256,4 +256,9 @@ const format = (fmt: string, ...parameters: any[]): string => {
   })
 }
 
-export default format
+export {
+  format as default,
+  quoteIdent as ident,
+  quoteLiteral as literal,
+  quoteString as string
+}


### PR DESCRIPTION
This exports

 - quoteIdent as ident,
 - quoteLiteral as literal,
 - quoteString as string

to better match the original library's API.

This also adds the tests for the above from
https://github.com/datalanche/node-pg-format/blob/master/test/index.js#L9

Closes #57